### PR TITLE
option to use localized object names

### DIFF
--- a/src/plugins/PerfCounterMuninNodePlugin.cpp
+++ b/src/plugins/PerfCounterMuninNodePlugin.cpp
@@ -44,6 +44,53 @@ PerfCounterMuninNodePlugin::~PerfCounterMuninNodePlugin()
   }
 }
 
+const TCHAR *PerfCounterMuninNodePlugin::GetPdhCounterLocalizedName(const TCHAR *englishName)
+{
+	TCHAR *regBuffer;
+	DWORD regBufferSize = 4096;
+	DWORD status;
+
+	do {
+		regBuffer = new TCHAR[regBufferSize];
+		status = RegQueryValueEx(HKEY_PERFORMANCE_DATA, L"Counter 009", NULL, NULL, (LPBYTE)regBuffer, &regBufferSize);
+
+		if (status == ERROR_MORE_DATA) {
+			delete regBuffer;
+			regBufferSize += 4096;
+		} else {
+			if (status != ERROR_SUCCESS) {
+				delete regBuffer;
+				_Module.LogEvent("PerfCounter plugin: %s: RegQueryValueEx error=%x", m_Name.c_str(), status);
+				return englishName;
+			}
+		}
+	} while (status != ERROR_SUCCESS);
+
+	DWORD fIndex = -1;
+
+	for (TCHAR *idx = regBuffer; *idx; idx += wcslen(idx) + 1) {
+		TCHAR *cName = idx + wcslen(idx) + 1;
+		if (_wcsicmp(cName, englishName) == 0) {
+			fIndex = _wtol(idx);
+			break;
+		}
+		idx = cName;
+	}
+
+	delete regBuffer;
+	
+	DWORD bufSize = 0;
+	PdhLookupPerfNameByIndex(NULL, fIndex, NULL, &bufSize);
+	TCHAR *localName = new TCHAR[bufSize];
+	status = PdhLookupPerfNameByIndex(NULL, fIndex, localName, &bufSize);
+	if (status != ERROR_SUCCESS) {
+		_Module.LogError("PerfCounter plugin: %s: Could not find a local name for %ls, error=%x", m_Name.c_str(), englishName, status);
+		return englishName;
+	}
+	return localName;
+}
+
+
 bool PerfCounterMuninNodePlugin::OpenCounter()
 {
   PDH_STATUS status;  
@@ -70,6 +117,10 @@ bool PerfCounterMuninNodePlugin::OpenCounter()
   
   DWORD counterListLength = 0;  
   DWORD instanceListLength = 0;
+  if (g_Config.GetValueB(m_SectionName, "UseEnglishObjectNames", true)) {
+	  counterName = GetPdhCounterLocalizedName(counterName.c_str());
+	  objectName = GetPdhCounterLocalizedName(objectName.c_str());
+  }
   status = PdhEnumObjectItems(NULL, NULL, objectName.c_str(), NULL, &counterListLength, NULL, &instanceListLength, PERF_DETAIL_EXPERT, 0);
   if (status != PDH_MORE_DATA) {
 	  _Module.LogError("PerfCounter plugin: %s: PdhEnumObjectItems error=%x", m_Name.c_str(), status);

--- a/src/plugins/PerfCounterMuninNodePlugin.h
+++ b/src/plugins/PerfCounterMuninNodePlugin.h
@@ -15,6 +15,7 @@ public:
   static const char *SectionPrefix;
 private:
   bool OpenCounter();
+  const TCHAR *PerfCounterMuninNodePlugin::GetPdhCounterLocalizedName(const TCHAR *englishName);
 
   bool m_Loaded;
   std::string m_SectionName;


### PR DESCRIPTION
performance counter names are localized in the system locale, this makes
the .ini files non-portable, so introduce the translation mechanism to
have the .ini file use English counter names, the localized names are
then looked up in the registry

Tested on Windows 8 and German Windows Server 2008 R2.
