### PR TITLE
Fix crash bug when the performance counter explanation was null.

### DIFF
--- a/src/plugins/PerfCounterMuninNodePlugin.cpp
+++ b/src/plugins/PerfCounterMuninNodePlugin.cpp
@@ -248,7 +248,7 @@ int PerfCounterMuninNodePlugin::GetConfig(char *buffer, int len)
     std::string graphTitle = g_Config.GetValue(m_SectionName, "GraphTitle", "Disk Time");
     std::string graphCategory = g_Config.GetValue(m_SectionName, "GraphCategory", "system");
     std::string graphArgs = g_Config.GetValue(m_SectionName, "GraphArgs", "--base 1000 -l 0");
-	std::string explainText = W2AConvert(info->szExplainText);
+    std::string explainText = info->szExplainText ? W2AConvert(info->szExplainText) : m_CounterNames[0].c_str();
 	std::string counterName = W2AConvert(info->szCounterName);
     printCount = _snprintf(buffer, len, "graph_title %s\n"
       "graph_category %s\n"


### PR DESCRIPTION
This fixes a crash bug in the Perf Counter plugin, when the perf counter's explanation text is null.

Let me know if you have any questions about it or need anything else.
Thanks!
