### PR TITLE
Disktime Fix

### DIFF
--- a/src/plugins/disk/DiskTimeMuninNodePlugin.cpp
+++ b/src/plugins/disk/DiskTimeMuninNodePlugin.cpp
@@ -77,7 +77,7 @@ bool DiskTimeMuninNodePlugin::OpenCounter()
   int pos = 0;
   TCHAR *instanceName = instanceList;
   while (instanceName[0] != NULL && instanceName[1] != NULL) {
-    std::string diskName = T2AConvert(instanceName);
+    TString diskName = W2TConvert(instanceName);
     m_DiskTimeNames.push_back(diskName);
     while (instanceName[0] != NULL)
       instanceName++;
@@ -136,7 +136,8 @@ int DiskTimeMuninNodePlugin::GetConfig(char *buffer, int len)
 
     assert(m_DiskTimeNames.size() == m_DiskTimeCounters.size());
     for (size_t i = 0; i < m_DiskTimeNames.size(); i++) {
-      printCount = _snprintf(buffer, len, "disktime_%i_.label %s\n", i, m_DiskTimeNames[i].c_str());
+      std::string diskName = T2AConvert(m_DiskTimeNames[i]);
+      printCount = _snprintf(buffer, len, "disktime_%i_.label %s\n", i, diskName.c_str());
       len -= printCount;
       buffer += printCount;
     }

--- a/src/plugins/disk/DiskTimeMuninNodePlugin.h
+++ b/src/plugins/disk/DiskTimeMuninNodePlugin.h
@@ -20,6 +20,6 @@ private:
 
   bool m_Loaded;
   HQUERY m_PerfQuery;
-  std::vector<std::string> m_DiskTimeNames;
+  std::vector<TString> m_DiskTimeNames;
   std::vector<HCOUNTER> m_DiskTimeCounters;
 };


### PR DESCRIPTION
The disk names were not handled properly when the _UNICODE symbol was defined and thus no disk times were reported. The diskTimeCounterPath was not set correctly to L"\LogicalDisk(HarddiskVolume1)\% Disk Time" for example, instead the "HarddiskVolume1" was a single byte character string, interpreted as multi-byte character string which led to chinese characters garbage and as a consequence to failing PdhCollectQueryData calls.
Please double check the patch for memory leaks! I saw some memory leak detection report in Visual Studio but could not clearly identify my changes as the source of the leak.
