### PR TITLE
[Patch]: fix build error VS2013 later

### DIFF
--- a/src/core/MuninNodeClient.cpp
+++ b/src/core/MuninNodeClient.cpp
@@ -21,6 +21,7 @@
 #include "Service.h"
 #include "../extra/verinfo.h"
 #include <vector>
+#include <algorithm>
 
 MuninNodeClient::MuninNodeClient(JCSocket *client, JCThread *server, MuninPluginManager *pluginManager) 
   : m_Client(client)


### PR DESCRIPTION
can't build VS2013 and VS2015(preview).

std::min methods need "#include <algorithm>"