### PR TITLE
[Patch]: fix the calculation of the swap area is wrong

### DIFF
--- a/src/plugins/memory/MemoryMuninNodePlugin.cpp
+++ b/src/plugins/memory/MemoryMuninNodePlugin.cpp
@@ -63,6 +63,6 @@ int MemoryMuninNodePlugin::GetValues(char *buffer, int len)
     "swap.value %llu\n"
     "free.value %llu\n"
     //"committed.value %u\n"
-    ".\n", mem.ullTotalPhys-mem.ullAvailPhys, mem.ullTotalPageFile-mem.ullAvailPageFile, mem.ullAvailPhys);
+    ".\n", mem.ullTotalPhys-mem.ullAvailPhys, (mem.ullTotalPageFile-mem.ullAvailPageFile-mem.ullTotalPhys+mem.ullAvailPhys), mem.ullAvailPhys);
   return 0;
 }


### PR DESCRIPTION
My environment page file is 2GB. 
But , leave the display of more than 2GB swap in munin

In the current calculation, the memory in use would also be included in the swap

![memory](https://cloud.githubusercontent.com/assets/44907/6462722/f232afc6-c1ee-11e4-908e-718494a41ba4.png)