### PR TITLE
Close rejected connections

### DIFF
--- a/src/core/MuninNodeServer.cpp
+++ b/src/core/MuninNodeServer.cpp
@@ -30,12 +30,12 @@ void MuninNodeServer::Stop()
 
 void *MuninNodeServer::Entry()
 {	
-	int portNumber = g_Config.GetValueI("MuninNode", "PortNumber", 4949);
-	bool logConnections = g_Config.GetValueB("MuninNode", "LogConnections", true);
-	std::string masterAddress = g_Config.GetValue("MuninNode", "MasterAddress", "*");
-	//std::string bindAddress = g_Config.GetValue("MuninNode", "BindAddress", "");
-	
-	//the socket function creates our SOCKET  
+  int portNumber = g_Config.GetValueI("MuninNode", "PortNumber", 4949);
+  bool logConnections = g_Config.GetValueB("MuninNode", "LogConnections", true);
+  std::string masterAddress = g_Config.GetValue("MuninNode", "MasterAddress", "*");
+  //std::string bindAddress = g_Config.GetValue("MuninNode", "BindAddress", "");
+
+  //the socket function creates our SOCKET  
   if (!m_ServerSocket.Create()) {
     return 0;
   }
@@ -62,19 +62,19 @@ void *MuninNodeServer::Entry()
     if (m_ServerSocket.Accept(client)) {
       // TODO: Add ip address matching, http://stackoverflow.com/questions/594112/matching-an-ip-to-a-cidr-mask-in-php5
       const char *ipAddress = inet_ntoa(client->m_Address.sin_addr);
-      if( !ipAddress )
-         ipAddress = "unknown address";
-	  if (masterAddress == "*" || ipAddress == masterAddress) {
-		  if(logConnections){
-			_Module.LogEvent("Connection from %s", ipAddress);
-		  }
-		  // Start child thread to process client socket
-		  MuninNodeClient *clientThread = new MuninNodeClient(client, this, &m_PluginManager);
-		  clientThread->Run();
-	  } else {
-		  _Module.LogError("Rejecting connection from %s", ipAddress);
-		  delete client;
-	  }
+      if ( !ipAddress )
+        ipAddress = "unknown address";
+        if (masterAddress == "*" || ipAddress == masterAddress) {
+          if (logConnections) {
+            _Module.LogEvent("Connection from %s", ipAddress);
+          }
+          // Start child thread to process client socket
+          MuninNodeClient *clientThread = new MuninNodeClient(client, this, &m_PluginManager);
+          clientThread->Run();
+        } else {
+          _Module.LogError("Rejecting connection from %s", ipAddress);
+          delete client;
+        }
     } else {
       delete client;
       break;

--- a/src/core/MuninNodeServer.cpp
+++ b/src/core/MuninNodeServer.cpp
@@ -73,6 +73,7 @@ void *MuninNodeServer::Entry()
 		  clientThread->Run();
 	  } else {
 		  _Module.LogError("Rejecting connection from %s", ipAddress);
+		  delete client;
 	  }
     } else {
       delete client;


### PR DESCRIPTION
After a connection has been rejected, we need to close that connection. This patch does that, thereby fixing the leaking of memory and network sockets.
the second commit in this PR simply makes the indentation in the file consistent but does not change any code.
