### PR TITLE
Improve the network plugin

### DIFF
--- a/src/plugins/network/NetworkMuninNodePlugin.cpp
+++ b/src/plugins/network/NetworkMuninNodePlugin.cpp
@@ -106,6 +106,7 @@ static int doiftable(int mode, std::string &myout) {
     }
     myout += "\n";
   }
+  free(mibiftable);
   return 0;
 }
 

--- a/src/plugins/network/NetworkMuninNodePlugin.cpp
+++ b/src/plugins/network/NetworkMuninNodePlugin.cpp
@@ -18,6 +18,7 @@
 
 #include "StdAfx.h"
 #include "NetworkMuninNodePlugin.h"
+#include <iphlpapi.h>
 
 NetworkMuninNodePlugin::NetworkMuninNodePlugin()
 {
@@ -27,36 +28,129 @@ NetworkMuninNodePlugin::~NetworkMuninNodePlugin()
 {
 }
 
+static int doiftable(int mode, string &myout) {
+  DWORD iftsize = sizeof(MIB_IFTABLE) * 1;
+  MIB_IFTABLE * mibiftable = (MIB_IFTABLE *)malloc(iftsize);
+  if (mibiftable == NULL) {
+    return 1;
+  }
+  if (GetIfTable(mibiftable, &iftsize, FALSE) == ERROR_INSUFFICIENT_BUFFER) {
+	// this failed, but set iftsize to the required size. So lets allocate that.
+    free(mibiftable);
+    mibiftable = (MIB_IFTABLE *)malloc(iftsize);
+    if (mibiftable == NULL) {
+      return 1;
+    }
+  }
+  if (GetIfTable(mibiftable, &iftsize, FALSE) != NO_ERROR) {
+	return 1;
+  }
+  for (DWORD i = 0; i < mibiftable->dwNumEntries; i++) {
+    MIB_IFROW * mibifrow = (MIB_IFROW *)&mibiftable->table[i];
+    if (mibifrow->dwType != IF_TYPE_ETHERNET_CSMACD) { // not Ethernet
+      continue;
+    }
+	if (mibifrow->dwOperStatus != IF_OPER_STATUS_OPERATIONAL) { //not operational
+      continue;
+	}
+	if (mibifrow->dwAdminStatus != 1) { // administratively disabled
+      continue;
+    }
+	if (mibifrow->dwSpeed == 0x40000000) { // nonsense ifSpeed
+	  continue;
+    }
+    char ifid[64];
+	sprintf(ifid, "%d", mibifrow->dwIndex);
+    myout += "multigraph if_eth"; myout += ifid; myout += "\n";
+    if (mode == 0) {
+      // print config
+      myout += "graph_order down up\n";
+      myout += "graph_title interface eth"; myout += ifid; myout += " traffic\n";
+      myout += "graph_args --base 1000\n";
+      myout += "graph_vlabel bits in (-) / out (+) per ${graph_period}\n";
+      myout += "graph_category network\n";
+      myout += "graph_info This graph shows the traffic of the windows interface with index ";
+      myout += ifid;
+      myout += ". Its description is ";
+      char cleandescr[101];
+      for (DWORD j = 0; j < sizeof(cleandescr); j++) {
+        if ((mibifrow->bDescr[j] < 32) && (mibifrow->bDescr[j] > 126)) {
+          mibifrow->bDescr[j] = '?';
+        }
+        if (j >= mibifrow->dwDescrLen) {
+          cleandescr[j] = 0;
+          break;
+        }
+        cleandescr[j] = mibifrow->bDescr[j];
+      }
+      cleandescr[100] = 0;
+      myout += cleandescr;
+      myout += ".\n";
+      myout += "down.label received\n";
+      myout += "down.type COUNTER\n";
+      myout += "down.graph no\n";
+      myout += "down.cdef down,8,*\n";
+      myout += "down.min 0\n";
+      myout += "up.label bps\n";
+      myout += "up.type COUNTER\n";
+      myout += "up.negative down\n";
+      myout += "up.cdef up,8,*\n";
+      myout += "up.min 0\n";
+      myout += "up.info Traffic of the interface with index "; myout += ifid; myout += ".\n";
+    } else {
+      // Print values
+      char valout[64];
+      sprintf(valout, "%ld", mibifrow->dwInOctets);
+      myout += "down.value "; myout += valout; myout += "\n";
+      sprintf(valout, "%ld", mibifrow->dwOutOctets);
+      myout += "up.value "; myout += valout; myout += "\n";
+    }
+    myout += "\n";
+  }
+  return 0;
+}
+
 int NetworkMuninNodePlugin::GetConfig(char *buffer, int len) {
-  strncpy(buffer, "graph_order down up\n"
-    "graph_title network traffic\n"
-    "graph_args --base 1000\n"
-    "graph_vlabel packets in (-) / out (+) per ${graph_period}\n"
-    "graph_category network\n"
-    "graph_info This graph shows the traffic of the network interfaces. Please note that the traffic is shown in packets per second, not bytes.\n"
-    "down.label pps\n"
-    "down.type COUNTER\n"
-    "down.graph no\n"
-    "up.label pps\n"
-    "up.type COUNTER\n"
-    "up.negative down\n"
-    "up.info Traffic of the interfaces. Maximum speed is 54000000 packets per second.\n"
-    "up.max 54000000\n"
-    "down.max 54000000\n"
-    ".\n", len);
+  string myout("");
+  myout += "multigraph network\n";
+  myout += "graph_order down up\n";
+  myout += "graph_title network traffic\n";
+  myout += "graph_args --base 1000\n";
+  myout += "graph_vlabel packets in (-) / out (+) per ${graph_period}\n";
+  myout += "graph_category network\n";
+  myout += "graph_info This graph shows the traffic of the network interfaces. Please note that the traffic is shown in packets per second, not bytes.\n";
+  myout += "down.label pps\n";
+  myout += "down.type COUNTER\n";
+  myout += "down.graph no\n";
+  myout += "up.label pps\n";
+  myout += "up.type COUNTER\n";
+  myout += "up.negative down\n";
+  myout += "up.info Traffic of the interfaces. Maximum speed is 54000000 packets per second.\n";
+  myout += "up.max 54000000\n";
+  myout += "down.max 54000000\n";
+  myout += "\n";
+  doiftable(0, myout);
+  myout += ".\n";
+  strncpy(buffer, myout.c_str(), len);
   return 0;
 };
 
 int NetworkMuninNodePlugin::GetValues(char *buffer, int len) { 
-  int ret = 0;
   MIB_TCPSTATS tcpStats;
   MIB_UDPSTATS udpStats;
 
-  ret = GetTcpStatistics(&tcpStats);
-  ret = GetUdpStatistics(&udpStats);
-  _snprintf(buffer, len, "down.value %i\nup.value %i\n.\n", 
+  string myout("");
+  myout += "multigraph network\n";
+  GetTcpStatistics(&tcpStats);
+  GetUdpStatistics(&udpStats);
+  char packetcntrstr[200];
+  sprintf(packetcntrstr,
+    "down.value %i\nup.value %i\n\n", 
     tcpStats.dwInSegs + udpStats.dwInDatagrams,
     tcpStats.dwOutSegs + udpStats.dwOutDatagrams);
-
+  myout += packetcntrstr;
+  doiftable(1, myout);
+  myout += ".\n";
+  strncpy(buffer, myout.c_str(), len);
   return 0;
 };

--- a/src/plugins/network/NetworkMuninNodePlugin.cpp
+++ b/src/plugins/network/NetworkMuninNodePlugin.cpp
@@ -21,14 +21,6 @@
 
 NetworkMuninNodePlugin::NetworkMuninNodePlugin()
 {
-  m_LastUdpPacketInCount = 0;
-  m_LastUdpPacketOutCount = 0;
-  m_LastTcpPacketInCount = 0;
-  m_LastTcpPacketOutCount = 0;
-
-  // Get the initial packet counts
-  char buffer[65] = {0};
-  GetValues(buffer, 64);
 }
 
 NetworkMuninNodePlugin::~NetworkMuninNodePlugin()
@@ -36,7 +28,6 @@ NetworkMuninNodePlugin::~NetworkMuninNodePlugin()
 }
 
 int NetworkMuninNodePlugin::GetConfig(char *buffer, int len) {
-  int ret = 0;
   strncpy(buffer, "graph_order down up\n"
     "graph_title network traffic\n"
     "graph_args --base 1000\n"

--- a/src/plugins/network/NetworkMuninNodePlugin.cpp
+++ b/src/plugins/network/NetworkMuninNodePlugin.cpp
@@ -58,6 +58,9 @@ static int doiftable(int mode, std::string &myout) {
     if (mibifrow->dwSpeed == 0x40000000) { // nonsense ifSpeed
       continue;
     }
+    if (mibifrow->dwPhysAddrLen < 6) { // nonsense PhysAddr
+      continue;
+    }
     char ifid[64];
     sprintf(ifid, "%lu", mibifrow->dwIndex);
     myout += "multigraph if_eth"; myout += ifid; myout += "\n";

--- a/src/plugins/network/NetworkMuninNodePlugin.cpp
+++ b/src/plugins/network/NetworkMuninNodePlugin.cpp
@@ -35,31 +35,31 @@ static int doiftable(int mode, std::string &myout) {
     return 1;
   }
   if (GetIfTable(mibiftable, &iftsize, FALSE) == ERROR_INSUFFICIENT_BUFFER) {
-	// this failed, but set iftsize to the required size. So lets allocate that.
+    // this failed, but set iftsize to the required size. So lets allocate that.
     mibiftable = (MIB_IFTABLE *)realloc(mibiftable, iftsize);
     if (mibiftable == NULL) {
       return 1;
     }
   }
   if (GetIfTable(mibiftable, &iftsize, FALSE) != NO_ERROR) {
-	return 1;
+    return 1;
   }
   for (DWORD i = 0; i < mibiftable->dwNumEntries; i++) {
     MIB_IFROW * mibifrow = (MIB_IFROW *)&mibiftable->table[i];
     if (mibifrow->dwType != IF_TYPE_ETHERNET_CSMACD) { // not Ethernet
       continue;
     }
-	if (mibifrow->dwOperStatus != IF_OPER_STATUS_OPERATIONAL) { //not operational
-      continue;
-	}
-	if (mibifrow->dwAdminStatus != 1) { // administratively disabled
+    if (mibifrow->dwOperStatus != IF_OPER_STATUS_OPERATIONAL) { //not operational
       continue;
     }
-	if (mibifrow->dwSpeed == 0x40000000) { // nonsense ifSpeed
-	  continue;
+    if (mibifrow->dwAdminStatus != 1) { // administratively disabled
+      continue;
+    }
+    if (mibifrow->dwSpeed == 0x40000000) { // nonsense ifSpeed
+      continue;
     }
     char ifid[64];
-	sprintf(ifid, "%lu", mibifrow->dwIndex);
+    sprintf(ifid, "%lu", mibifrow->dwIndex);
     myout += "multigraph if_eth"; myout += ifid; myout += "\n";
     if (mode == 0) {
       // print config

--- a/src/plugins/network/NetworkMuninNodePlugin.h
+++ b/src/plugins/network/NetworkMuninNodePlugin.h
@@ -11,9 +11,4 @@ public:
   virtual int GetConfig(char *buffer, int len);
   virtual int GetValues(char *buffer, int len);
   virtual bool IsLoaded() { return true; };
-private:
-  DWORD m_LastUdpPacketInCount;
-  DWORD m_LastUdpPacketOutCount;
-  DWORD m_LastTcpPacketInCount;
-  DWORD m_LastTcpPacketOutCount;
 };


### PR DESCRIPTION
This PR significantly improves the network plugin. Instead of creating one rather useless "packets/s" graph, it is now a multigraph plugin, and will in one go create one "bits in/out" graph per interface. The graphs try to look just like the ones generated by the standard if_ plugin on lunix hosts.

Caveats:
- this hasn't been tested much yet.
- I don't usually do windows or C++ programming.
