### PR TITLE
fixed from PVS-Studio

### DIFF
--- a/src/extra/registry.cpp
+++ b/src/extra/registry.cpp
@@ -124,7 +124,7 @@ double CRegistry::GetValueF(string const valName, double const defValue)
 
 	if (type == REG_SZ)
 		return atof( T2AConvert(stackValue).c_str() ); 
-	else if (type = REG_DWORD)
+	else if (type == REG_DWORD)
 		return *((DWORD*)stackValue);
 	else
 	{


### PR DESCRIPTION
I'm a member of the Pinguem.ru competition on finding errors in open source projects. A bug, found using PVS-Studio. Warnings:

[V559](https://www.viva64.com/en/w/v559/) Suspicious assignment inside the condition expression of 'if' operator: type = (4). registry.cpp 127