### PR TITLE
fixed from PVS-Studio

### DIFF
--- a/src/plugins/PerfCounterMuninNodePlugin.cpp
+++ b/src/plugins/PerfCounterMuninNodePlugin.cpp
@@ -55,11 +55,11 @@ const TCHAR *PerfCounterMuninNodePlugin::GetPdhCounterLocalizedName(const TCHAR 
 		status = RegQueryValueEx(HKEY_PERFORMANCE_DATA, L"Counter 009", NULL, NULL, (LPBYTE)regBuffer, &regBufferSize);
 
 		if (status == ERROR_MORE_DATA) {
-			delete regBuffer;
+			delete [] regBuffer;
 			regBufferSize += 4096;
 		} else {
 			if (status != ERROR_SUCCESS) {
-				delete regBuffer;
+				delete [] regBuffer;
 				_Module.LogEvent("PerfCounter plugin: %s: RegQueryValueEx error=%x", m_Name.c_str(), status);
 				return englishName;
 			}


### PR DESCRIPTION
I'm a member of the Pinguem.ru competition on finding errors in open source projects. A bug, found using PVS-Studio. Warnings:

[V611](https://www.viva64.com/en/w/v611/) The memory was allocated using 'new T[]' operator but was released using the 'delete' operator. Consider inspecting this code. It's probably better to use 'delete [] regBuffer;'. perfcountermuninnodeplugin.cpp 58, 62