### PR TITLE
fixed from PVS-Studio

### DIFF
--- a/src/core/Service.cpp
+++ b/src/core/Service.cpp
@@ -314,7 +314,7 @@ void CService::LogEvent(LPCSTR pFormat, ...)
   else
   {
     // As we don't have an event log handle, just write the error to the console.
-    printf(chMsg);
+    printf("%s", chMsg);
     printf("\n");
     fflush(stdout);
   }
@@ -338,7 +338,7 @@ void CService::LogError(LPCSTR pFormat, ...)
   {
     // As we don't have an event log handle, just write the error to the console.
 	printf("ERROR:");
-    printf(chMsg);
+    printf("%s", chMsg);
     printf("\n");
     fflush(stdout);
   }


### PR DESCRIPTION
I'm a member of the Pinguem.ru competition on finding errors in open source projects. A bug, found using PVS-Studio. Warnings:

[V618](https://www.viva64.com/en/w/v618/) It's dangerous to call the 'printf' function in such a manner, as the line being passed could contain format specification. The example of the safe code: printf("%s", str); service.cpp 317, 341