### PR TITLE
fixed from PVS-Studio

### DIFF
--- a/src/extra/XEventLog.cpp
+++ b/src/extra/XEventLog.cpp
@@ -441,12 +441,15 @@ void CXEventLog::SetAppName(LPCTSTR lpszApp)
 {
 	if (!lpszApp)
 		return;
-	if (!m_pszAppName)
-		m_pszAppName = new TCHAR [_MAX_PATH*2];
-	if (m_pszAppName)
-	{
-		memset(m_pszAppName, 0, _MAX_PATH*2*sizeof(TCHAR));
-		_tcsncpy(m_pszAppName, lpszApp, _MAX_PATH*2-2);
+
+	try {
+		if (!m_pszAppName)
+			m_pszAppName = new TCHAR[_MAX_PATH * 2];
+
+		memset(m_pszAppName, 0, _MAX_PATH * 2 * sizeof(TCHAR));
+		_tcsncpy(m_pszAppName, lpszApp, _MAX_PATH * 2 - 2);
+	}
+	catch (std::bad_alloc& ba) {
 	}
 }
 

--- a/src/extra/registry.cpp
+++ b/src/extra/registry.cpp
@@ -64,24 +64,28 @@ string CRegistry::GetValue(const char* valName, string const defValue)
 	if (ret != ERROR_MORE_DATA)
 		return defValue;
 
-	BYTE* buffer = new BYTE[len];
-	if (buffer)
-	{
-		ret =  RegQueryValueEx(m_key, 
-			tValueName.c_str(), 
+	try {
+		BYTE* buffer = new BYTE[len];
+
+		ret = RegQueryValueEx(m_key,
+			tValueName.c_str(),
 			NULL,
-			&type, 
+			&type,
 			buffer,
 			&len);
-		if (ret == ERROR_SUCCESS)		
+		if (ret == ERROR_SUCCESS)
 		{
-			string r = T2AConvert( reinterpret_cast<TCHAR*>(buffer) );
+			string r = T2AConvert(reinterpret_cast<TCHAR*>(buffer));
 			delete[] buffer;
 			return r;
 		}
 		else
 			delete[] buffer;
 	}
+	catch (std::bad_alloc& ba) {
+
+	}
+
 	return defValue;
 }
 
@@ -124,7 +128,7 @@ double CRegistry::GetValueF(string const valName, double const defValue)
 
 	if (type == REG_SZ)
 		return atof( T2AConvert(stackValue).c_str() ); 
-	else if (type = REG_DWORD)
+	else if (type == REG_DWORD)
 		return *((DWORD*)stackValue);
 	else
 	{
@@ -237,24 +241,27 @@ vector<string> CRegistry::GetValues(const char* valName)
 	if (ret != ERROR_MORE_DATA)
 		return l;
 
-	BYTE* buffer = new BYTE[len];
-	if (buffer)
-	{
-		ret =  RegQueryValueEx(m_key, 
-			tValueName.c_str(), 
+	try {
+		BYTE* buffer = new BYTE[len];
+
+		ret = RegQueryValueEx(m_key,
+			tValueName.c_str(),
 			NULL,
-			&type, 
+			&type,
 			buffer,
 			&len);
-		if (ret == ERROR_SUCCESS)		
+		if (ret == ERROR_SUCCESS)
 		{
-			convert_multisz(reinterpret_cast<TCHAR*>(buffer), len, l);			
+			convert_multisz(reinterpret_cast<TCHAR*>(buffer), len, l);
 			delete[] buffer;
 			return l;
 		}
 		else
 			delete[] buffer;
 	}
+	catch (std::bad_alloc& ba) {
+	}
+
 	return l;
 }
 


### PR DESCRIPTION
I'm a member of the Pinguem.ru competition on finding errors in open source projects. A bug, found using PVS-Studio. Warnings:

[V668](https://www.viva64.com/en/w/v668/) There is no sense in testing the 'buffer' pointer against null, as the memory was allocated using the 'new' operator. The exception will be generated in the case of memory allocation error. registry.cpp 68
[V668](https://www.viva64.com/en/w/v668/) There is no sense in testing the 'buffer' pointer against null, as the memory was allocated using the 'new' operator. The exception will be generated in the case of memory allocation error. registry.cpp 241
[V668](https://www.viva64.com/en/w/v668/) There is no sense in testing the 'm_pszAppName' pointer against null, as the memory was allocated using the 'new' operator. The exception will be generated in the case of memory allocation error. xeventlog.cpp 446